### PR TITLE
Add preprocessor-level exclusion of GL functions in GLEAM

### DIFF
--- a/cmake/Packaging/EmscriptenBuild.cmake
+++ b/cmake/Packaging/EmscriptenBuild.cmake
@@ -29,7 +29,7 @@ macro ( EMSCRIPTEN_PACKAGE )
 
     set_target_properties ( ${EM_TARGET}
         PROPERTIES
-        LINK_FLAGS "${RSC_FLAGS}"
+        LINK_FLAGS "${${EM_TARGET}_RSC_FLAGS}"
         )
 
     install(

--- a/cmake/Toolchains/js-emscripten.toolchain.cmake
+++ b/cmake/Toolchains/js-emscripten.toolchain.cmake
@@ -27,7 +27,7 @@ option ( COFFEE_GENERATE_HTML
 option ( COFFEE_GENERATE_WASM
     "Generate WASM version of code, not asm.js" OFF )
 
-set ( EM_COMMON "-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=1 -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy -s USE_SDL=2 -s USE_ZLIB=1 -s USE_WEBGL2=1 -O2" )
+set ( EM_COMMON "-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=1 -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy -s USE_SDL=2 -s USE_ZLIB=1 -O2" )
 
 if(COFFEE_GENERATE_WASM)
     message ( STATUS "Generating WASM assembly" )

--- a/cmake/Toolchains/js-emscripten.toolchain.cmake
+++ b/cmake/Toolchains/js-emscripten.toolchain.cmake
@@ -27,7 +27,7 @@ option ( COFFEE_GENERATE_HTML
 option ( COFFEE_GENERATE_WASM
     "Generate WASM version of code, not asm.js" OFF )
 
-set ( EM_COMMON "-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=1 -s USE_SDL=2 -s USE_ZLIB=1 -O2" )
+set ( EM_COMMON "-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=1 -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy -s USE_SDL=2 -s USE_ZLIB=1 -s USE_WEBGL2=1 -O2" )
 
 if(COFFEE_GENERATE_WASM)
     message ( STATUS "Generating WASM assembly" )

--- a/coffee/core/private/coffee.cpp
+++ b/coffee/core/private/coffee.cpp
@@ -383,7 +383,8 @@ static void glibc_backtrace()
             std::rethrow_exception(exc_ptr);
     } catch(std::exception& e)
     {
-        cBasicPrint("{0}", StrUtil::multiply('-', Cmd::TerminalSize().w));
+        if(Cmd::Interactive())
+            cBasicPrint("{0}", StrUtil::multiply('-', Cmd::TerminalSize().w));
         cBasicPrint("exception encountered:");
         cBasicPrint(" >> {0}: {1}",
                  Stacktracer::DemangleSymbol(typeid(e).name()),

--- a/coffee/core/private/plat/environment/emscripten/sysinfo.cpp
+++ b/coffee/core/private/plat/environment/emscripten/sysinfo.cpp
@@ -1,6 +1,16 @@
 #include <coffee/core/plat/environment/emscripten/sysinfo.h>
 #include <coffee/core/CDebug>
 
+#include <emscripten.h>
+
+/* Can be used for workarounds, if necessary */
+EM_JS(char*, get_user_agent, (), {
+    var lengthBytes = lengthBytesUTF8(navigator.userAgent) + 1;
+    var wasmString = _malloc(lengthBytes);
+    stringToUTF8(navigator.userAgent, wasmString, lengthBytes + 1);
+    return wasmString;
+});
+
 namespace Coffee{
 namespace Environment{
 namespace Emscripten{

--- a/coffee/core/private/task_queue/task.cpp
+++ b/coffee/core/private/task_queue/task.cpp
@@ -74,6 +74,7 @@ static void ImpCreateNewThreadQueue(CString const& name, AtomicBool** flag)
 
 RuntimeQueue* RuntimeQueue::CreateNewThreadQueue(const CString& name)
 {
+    try{
     DProfContext _(DTEXT(RQ_API "Creating new task queue"));
     AtomicBool*  flagPtr = nullptr;
     Thread       t(ImpCreateNewThreadQueue, name, &flagPtr);
@@ -95,6 +96,11 @@ RuntimeQueue* RuntimeQueue::CreateNewThreadQueue(const CString& name)
     }
 
     return &context->queues.find(tid)->second;
+    } catch(std::exception const& e)
+    {
+        cWarning("Failed to create RuntimeQueue: {0}", e.what());
+        return nullptr;
+    }
 }
 
 RuntimeQueue* RuntimeQueue::GetCurrentQueue()

--- a/coffee/graphics/apis/gleam/private/levels/glbase.cpp
+++ b/coffee/graphics/apis/gleam/private/levels/glbase.cpp
@@ -1,21 +1,17 @@
 #include <coffee/graphics/apis/gleam/gleam.h>
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
 #include <coffee/graphics/apis/gleam/levels/desktop/glbase.h>
 #else
 #include <coffee/graphics/apis/gleam/levels/es/glbase.h>
 #endif
+
 namespace Coffee{
 namespace CGL{
 
 Coffee::CString CGL_Shared_Debug::s_ExtensionList = "";
 bool CGL_Shared_Debug::b_isDebugging = false;
 
-#ifdef COFFEE_GLEAM_DESKTOP
-Coffee::XML::Document* CGLXML::doc = nullptr;
-Coffee::Mutex CGLXML::doc_mutex;
-#else
-#endif
 Coffee::int32 CGL_Shared_Debug::Num_Internal_Formats = 0;
 Coffee::int32* CGL_Shared_Debug::Internal_Formats = nullptr;
 

--- a/coffee/graphics/apis/gleam/private/levels/shared/gl_shared_debug.cpp
+++ b/coffee/graphics/apis/gleam/private/levels/shared/gl_shared_debug.cpp
@@ -15,7 +15,7 @@ namespace CGL{
 void CGL_Shared_Debug::SetDebugMode(bool enabled)
 {
     C_USED(enabled);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     if(enabled == b_isDebugging)
         return;
     if(enabled)
@@ -276,28 +276,30 @@ static Map<u32, limit_name_t> limit_map = {
 
     A(L::Total_Base + L::ImageUnits, GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS),
 
-    #if !defined(COFFEE_ONLY_GLES20)
+    #if GL_VERSION_VERIFY(0x330, 0x300)
     A(L::Vertex_Base + L::UniformVals,GL_MAX_VERTEX_UNIFORM_COMPONENTS),
-    A(L::Vertex_Base + L::AtomicCounters,GL_MAX_VERTEX_ATOMIC_COUNTERS),
-    A(L::Vertex_Base + L::AtomicBufs,GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS),
-    A(L::Vertex_Base + L::SSBO,GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS),
     A(L::Vertex_Base + L::UniformsBlocks,GL_MAX_VERTEX_UNIFORM_BLOCKS),
     A(L::Vertex_Base + L::Inputs,GL_MAX_VERTEX_ATTRIBS),
     A(L::Vertex_Base + L::Outputs,GL_MAX_VERTEX_OUTPUT_COMPONENTS),
-    A(L::Vertex_Base + L::ImageUniforms,GL_MAX_VERTEX_IMAGE_UNIFORMS),
-
     A(L::Fragment_Base+L::UniformVals,GL_MAX_FRAGMENT_UNIFORM_COMPONENTS),
-    A(L::Fragment_Base+L::AtomicCounters,GL_MAX_FRAGMENT_ATOMIC_COUNTERS),
-    A(L::Fragment_Base+L::AtomicBufs,GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS),
-    A(L::Fragment_Base + L::SSBO,GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS),
     A(L::Fragment_Base + L::UniformsBlocks,GL_MAX_FRAGMENT_UNIFORM_BLOCKS),
     A(L::Fragment_Base + L::Inputs,GL_MAX_FRAGMENT_INPUT_COMPONENTS),
     A(L::Fragment_Base + L::Outputs,GL_MAX_DRAW_BUFFERS),
+
+    #if GL_VERSION_VERIFY(0x330, 0x320)
+    A(L::Vertex_Base + L::AtomicCounters,GL_MAX_VERTEX_ATOMIC_COUNTERS),
+    A(L::Vertex_Base + L::AtomicBufs,GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS),
+    A(L::Vertex_Base + L::SSBO,GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS),
+    A(L::Vertex_Base + L::ImageUniforms,GL_MAX_VERTEX_IMAGE_UNIFORMS),
+    A(L::Fragment_Base+L::AtomicCounters,GL_MAX_FRAGMENT_ATOMIC_COUNTERS),
+    A(L::Fragment_Base+L::AtomicBufs,GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS),
+    A(L::Fragment_Base + L::SSBO,GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS),
     A(L::Fragment_Base + L::ImageUniforms,GL_MAX_FRAGMENT_IMAGE_UNIFORMS),
+    #endif
 
     #endif
 
-    #if defined(COFFEE_ONLY_GLES20)
+    #if GL_VERSION_VERIFY(0x330, 0x300)
     A(L::Vertex_Base + L::Outputs, GL_MAX_VARYING_VECTORS),
     A(L::Fragment_Base + L::Inputs, GL_MAX_VARYING_VECTORS),
     #endif
@@ -333,9 +335,11 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::VAO_ElementIndices,GL_MAX_ELEMENTS_INDICES),
     A(L::VAO_ElementVerts,GL_MAX_ELEMENTS_VERTICES),
 
+    #if GL_VERSION_VERIFY(0x330, 0x320)
     A(L::Vertex_AttrRelativeOff,GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET),
     A(L::Vertex_AttrStride,GL_MAX_VERTEX_ATTRIB_STRIDE),
     A(L::Vertex_AttrBindings,GL_MAX_VERTEX_ATTRIB_BINDINGS),
+    #endif
 
     #if defined(GL_MAX_VERTEX_STREAMS)
     A(L::Vertex_Streams,GL_MAX_VERTEX_STREAMS),
@@ -347,9 +351,11 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::Vertex_CombClipCullDists,GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES),
     #endif
 
+    #if GL_VERSION_VERIFY(0x330, 0x320)
     A(L::Geom_InComps,GL_MAX_GEOMETRY_INPUT_COMPONENTS),
     A(L::Geom_OutComps,GL_MAX_GEOMETRY_OUTPUT_COMPONENTS),
     A(L::Geom_OutVerts,GL_MAX_GEOMETRY_OUTPUT_VERTICES),
+    #endif
 
     #if defined(GL_MAX_TESS_PATCH_COMPONENTS)
     A(L::Tess_Patches,GL_MAX_TESS_PATCH_COMPONENTS),
@@ -358,10 +364,13 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::FBO_DrawBufs,GL_MAX_DRAW_BUFFERS),
     A(L::FBO_RendBufSize,GL_MAX_RENDERBUFFER_SIZE),
     A(L::FBO_ColorAtt,GL_MAX_COLOR_ATTACHMENTS),
+
+    #if GL_VERSION_VERIFY(0x330, 0x320)
     A(L::FBO_Width,GL_MAX_FRAMEBUFFER_WIDTH),
     A(L::FBO_Height,GL_MAX_FRAMEBUFFER_HEIGHT),
     A(L::FBO_Layers,GL_MAX_FRAMEBUFFER_LAYERS),
     A(L::FBO_Samples,GL_MAX_FRAMEBUFFER_SAMPLES),
+    #endif
 
     #if defined(GL_MAX_TRANSFORM_FEEDBACK_BUFFERS)
     A(L::XF_InterleavComps,GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS),
@@ -369,9 +378,11 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::XF_SeparateAttrs,GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS),
     #endif
 
+    #if GL_VERSION_VERIFY(0x330, 0x320)
     A(L::Dbg_LabelLen,GL_MAX_LABEL_LENGTH),
     A(L::Dbg_MessageLen,GL_MAX_DEBUG_MESSAGE_LENGTH),
     A(L::Dbg_LoggedMessages,GL_MAX_DEBUG_LOGGED_MESSAGES),
+    #endif
 
 //    #if defined(GL_MAX_SHADER_COMPILER_THREADS_ARB)
 //    A(L::Compile_Threads,GL_MAX_SHADER_COMPILER_THREADS_ARB),
@@ -380,7 +391,9 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::Compile_Threads,GL_MAX_SHADER_COMPILER_THREADS_KHR),
     #endif
 
+    #if GL_VERSION_VERIFY(0x330, 0x320)
     A(L::UniformLocs,GL_MAX_UNIFORM_LOCATIONS),
+    #endif
 
     A(L::UBO_Size,GL_MAX_UNIFORM_BLOCK_SIZE),
     #if defined(GL_MAX_SHADER_STORAGE_BLOCK_SIZE)

--- a/coffee/graphics/apis/gleam/private/levels/shared/gl_shared_debug.cpp
+++ b/coffee/graphics/apis/gleam/private/levels/shared/gl_shared_debug.cpp
@@ -33,7 +33,7 @@ void CGL_Shared_Debug::SetDebugMode(bool enabled)
 
 void CGL_Shared_Debug::GetExtensions()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
     int32 numExtensions = 0;
     numExtensions = GetInteger(GL_NUM_EXTENSIONS);
 
@@ -67,7 +67,7 @@ Display::CGLVersion CGL_Shared_Debug::ContextVersion()
     ver.revision = 0;
 
     /* In most cases, this will work wonders */
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     ver.major = C_CAST<uint8>(GetInteger(GL_MAJOR_VERSION));
     ver.minor = C_CAST<uint8>(GetInteger(GL_MINOR_VERSION));
 #else
@@ -89,7 +89,7 @@ Display::CGLVersion CGL_Shared_Debug::ContextVersion()
         if (str.size()<=0)
             break;
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x200, GL_VERSION_NONE)
         Regex::Pattern p = Regex::Compile("([0-9]+)\\.([0-9]+)\\.([0-9])?([\\s\\S]*)");
 #else
         Regex::Pattern p = Regex::Compile("OpenGL ES ([0-9]+)\\.([0-9]+)?([\\s\\S]*)");
@@ -125,11 +125,11 @@ Display::CGLVersion CGL_Shared_Debug::ShaderLanguageVersion()
 {
     Display::CGLVersion ver = {};
 
-#if !defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(GL_VERSION_NONE, 0x200)
     ver.revision = 1;
 #endif
 
-#if defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     ver.major = 1;
     ver.minor = 0;
 #endif
@@ -311,7 +311,7 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::Tex_SizeCube, GL_MAX_CUBE_MAP_TEXTURE_SIZE),
 
     /* Extended OpenGL 3.3+ limits */
-    #if !defined(COFFEE_ONLY_GLES20)
+    #if GL_VERSION_VERIFY(0x300, 0x300)
 
     #if defined(GL_MAX_3D_TEXTURE_SIZE)
     A(L::Tex_Size3D,GL_MAX_3D_TEXTURE_SIZE),
@@ -345,7 +345,7 @@ static Map<u32, limit_name_t> limit_map = {
     A(L::Vertex_Streams,GL_MAX_VERTEX_STREAMS),
     #endif
 
-    #if defined(COFFEE_GLEAM_DESKTOP)
+    #if GL_VERSION_VERIFY(0x330, GL_VERSION_NONE)
     A(L::Vertex_ClipDists,GL_MAX_CLIP_DISTANCES),
     A(L::Vertex_CullDists,GL_MAX_CULL_DISTANCES),
     A(L::Vertex_CombClipCullDists,GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES),
@@ -410,7 +410,8 @@ static Map<u32, limit_name_t> limit_map = {
     #if defined(GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE)
     A(L::AtomicBuf_Bindings,GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS),
     #endif
-    #endif
+
+    #endif // GL_VERSION_VERIFY(0x300, 0x300)
 };
 
 static Map<u32, limit_name_t> limit_map_2d =  {

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_buffer_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_buffer_rhi.cpp
@@ -14,7 +14,7 @@ STATICINLINE void VerifyBuffer(CGhnd h)
 
 void GLEAM_VBuffer::alloc()
 {
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
     if(GLEAM_FEATURES.direct_state)
         CGL45::BufAlloc(m_handle);
     else
@@ -35,7 +35,7 @@ void GLEAM_VBuffer::commit(szptr size, c_cptr data_)
 
     m_size = size;
     bind();
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x440, GL_VERSION_NONE)
     if(GLEAM_FEATURES.buffer_storage &&
        feval(m_access & ResourceAccess::Immutable))
     {
@@ -47,7 +47,7 @@ void GLEAM_VBuffer::commit(szptr size, c_cptr data_)
     } else
 #endif
     {
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
         if(GLEAM_FEATURES.direct_state)
             CGL45::BufData(m_handle, Bytes::Unsafe(data, m_size), m_access);
         else
@@ -58,7 +58,7 @@ void GLEAM_VBuffer::commit(szptr size, c_cptr data_)
 
 void* GLEAM_VBuffer::map(szptr offset, szptr size)
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300) && !defined(COFFEE_WEBGL)
     if(!GLEAM_FEATURES.gles20)
     {
         VerifyBuffer(m_handle);
@@ -74,7 +74,7 @@ void* GLEAM_VBuffer::map(szptr offset, szptr size)
         if(!GLEAM_FEATURES.buffer_persistent)
             acc ^= ResourceAccess::Persistent;
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
         if(GLEAM_FEATURES.direct_state)
             return CGL45::BufMapRange(
                 m_handle, C_FCAST<ptroff>(offset), C_FCAST<ptroff>(size), acc);
@@ -98,13 +98,13 @@ void* GLEAM_VBuffer::map(szptr offset, szptr size)
 
 void GLEAM_VBuffer::unmap()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300) && !defined(COFFEE_WEBGL)
     if(!GLEAM_FEATURES.gles20)
     {
         VerifyBuffer(m_handle);
 
         bind();
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x330, GL_VERSION_NONE)
         if(GLEAM_FEATURES.direct_state)
             CGL45::BufUnmap(m_handle);
         else
@@ -131,7 +131,7 @@ void GLEAM_VBuffer::unbind() const
 
 void GLEAM_BindableBuffer::bindrange(uint32 idx, szptr off, szptr size) const
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
     if(!GLEAM_FEATURES.gles20)
     {
         VerifyBuffer(m_handle);

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_framebuffer_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_framebuffer_rhi.cpp
@@ -92,7 +92,7 @@ void GLEAM_RenderTarget::attachSurface(const GLEAM_RenderDummy &rb)
 
 void GLEAM_RenderTarget::attachDepthStencilSurface(const GLEAM_Surface &s, uint32 mip)
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(!GLEAM_FEATURES.gles20)
     {
         fb_bind(m_type,m_handle);
@@ -127,7 +127,7 @@ void GLEAM_RenderTarget::blit(const CRect64 &src, GLEAM_RenderTarget &target,
 {
     GLEAM_ScopeMarker sc(GLM_API "blit");
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(!GLEAM_FEATURES.gles20)
     {
         this->bind(FramebufferT::Read);
@@ -149,31 +149,12 @@ void GLEAM_RenderTarget::blit(const CRect64 &src, GLEAM_RenderTarget &target,
 
 void GLEAM_RenderTarget::resize(uint32 i,CRect64 const& view)
 {
-//    fb_bind(m_type,m_handle);
-
     auto sz_arm_printable = view.convert<i32>();
     cVerbose(10, GLM_API "Resizing render target {0} to {1}x{2}",
              m_handle,
              sz_arm_printable.w, sz_arm_printable.h);
 
     m_size = sz_arm_printable.size();
-
-//#if !defined(COFFEE_ONLY_GLES20)
-//    if(!GLEAM_FEATURES.gles20 && CGL43::ViewportArraySupported())
-//    {
-//        auto r = view.convert<scalar>();
-//        CGL43::ViewportSet(i,r);
-//    }else
-//#endif
-//    {
-//        if(GL_DEBUG_MODE)
-//            if(i != 0)
-//                cWarning("Cannot perform task: applying viewport index, unsupported");
-//        if(i==0)
-//            CGL33::ViewportSet(view);
-//    }
-//    if(m_handle != 0)
-//        fb_bind(m_type,0);
 }
 
 CSize GLEAM_RenderTarget::size()

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_internal_types.h
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_internal_types.h
@@ -11,15 +11,13 @@ namespace Coffee{
 namespace RHI{
 namespace GLEAM{
 
-#ifndef COFFEE_GLEAM_DESKTOP
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
 using CGL33 = CGLES30;
 using CGL43 = CGLES32;
 using CGL45 = CGLES32;
-#else
+#elif GL_VERSION_VERIFY(GL_VERSION_NONE, 0x200)
 using CGL33 = CGLES20;
 using CGL43 = CGLES20;
-#endif
 #endif
 
 using namespace CGL;
@@ -45,7 +43,7 @@ struct GLEAM_PboQueue
 
 struct GLEAM_Instance_Data
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     GLEAM_PboQueue pboQueue;
 #endif
     struct {

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_profiler_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_profiler_rhi.cpp
@@ -34,7 +34,7 @@ GLEAM_PrfQuery::GLEAM_PrfQuery(ProfilingTerm term):
 
 void GLEAM_PrfQuery::begin()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(m_handle == 0)
         alloc();
 
@@ -44,21 +44,21 @@ void GLEAM_PrfQuery::begin()
 
 void GLEAM_PrfQuery::end()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     CGL33::QueryEnd(m_type);
 #endif
 }
 
 int64 GLEAM_PrfQuery::resulti()
 {
-#if !defined(COFFEE_ONLY_GLES20)
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     int64 v;
     CGL33::QueryGetObjecti64v(m_handle,GL_QUERY_RESULT,&v);
-#else
+#elif GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
     uint32 v;
     CGL33::QueryGetObjectuiv(m_handle,GL_QUERY_RESULT,&v);
 #endif
+#if GL_VERSION_VERIFY(0x300, 0x300)
     return v;
 #else
     return 0;
@@ -67,14 +67,14 @@ int64 GLEAM_PrfQuery::resulti()
 
 uint64 GLEAM_PrfQuery::resultu()
 {
-#if !defined(COFFEE_ONLY_GLES20)
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     uint64 v;
     CGL33::QueryGetObjectui64v(m_handle,GL_QUERY_RESULT,&v);
-#else
+#elif GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
     uint32 v;
     CGL33::QueryGetObjectuiv(m_handle,GL_QUERY_RESULT,&v);
 #endif
+#if GL_VERSION_VERIFY(0x300, 0x300)
     return v;
 #else
     return 0;
@@ -224,14 +224,14 @@ void GLEAM_DBufQuery::end()
 GLEAM_ScopeMarker::GLEAM_ScopeMarker(cstring tag)
     :GraphicsDebug::ScopeMarker(tag)
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     CGL33::Debug::SetDebugGroup(tag, 0);
 #endif
 }
 
 GLEAM_ScopeMarker::~GLEAM_ScopeMarker()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     CGL33::Debug::UnsetDebugGroup();
 #endif
 }

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_query_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_query_rhi.cpp
@@ -7,7 +7,7 @@ namespace GLEAM{
 
 void GLEAM_Query::alloc()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(GLEAM_FEATURES.gles20)
         CGL33::QueryAlloc(m_handle);
 #endif
@@ -15,7 +15,7 @@ void GLEAM_Query::alloc()
 
 void GLEAM_Query::dealloc()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(GLEAM_FEATURES.gles20)
         CGL33::QueryFree(m_handle);
 #endif
@@ -23,7 +23,7 @@ void GLEAM_Query::dealloc()
 
 void GLEAM_OccludeQuery::begin()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(GLEAM_FEATURES.gles20)
     {
         if(m_handle == 0)
@@ -37,7 +37,7 @@ void GLEAM_OccludeQuery::begin()
 
 void GLEAM_OccludeQuery::end()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(GLEAM_FEATURES.gles20)
     {
         CGL33::ColorMask({1,1,1,1,0});
@@ -49,14 +49,14 @@ void GLEAM_OccludeQuery::end()
 
 int64 GLEAM_OccludeQuery::resulti()
 {
-#if !defined(COFFEE_ONLY_GLES20)
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     int64 v;
     CGL33::QueryGetObjecti64v(m_handle,GL_QUERY_RESULT,&v);
-#else
+#elif GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
     uint32 v;
     CGL33::QueryGetObjectuiv(m_handle,GL_QUERY_RESULT,&v);
 #endif
+#if GL_VERSION_VERIFY(0x300, 0x300)
     return v;
 #else
     return 0;
@@ -65,20 +65,18 @@ int64 GLEAM_OccludeQuery::resulti()
 
 uint64 GLEAM_OccludeQuery::resultu()
 {
-#if !defined(COFFEE_ONLY_GLES20)
-    if(GLEAM_FEATURES.gles20)
-    {
-#ifdef COFFEE_GLEAM_DESKTOP
-        uint64 v;
-        CGL33::QueryGetObjectui64v(m_handle,GL_QUERY_RESULT,&v);
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
+    uint64 v;
+    CGL33::QueryGetObjectui64v(m_handle,GL_QUERY_RESULT,&v);
+#elif GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
+    uint32 v;
+    CGL33::QueryGetObjectuiv(m_handle,GL_QUERY_RESULT,&v);
+#endif
+#if GL_VERSION_VERIFY(0x300, 0x300)
+    return v;
 #else
-        uint32 v;
-        CGL33::QueryGetObjectuiv(m_handle,GL_QUERY_RESULT,&v);
+    return 0;
 #endif
-        return v;
-    }else
-#endif
-        return 0;
 }
 
 }

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_shader_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_shader_rhi.cpp
@@ -303,7 +303,7 @@ bool GLEAM_Shader::compile(ShaderStage stage, const Bytes &data)
 
         return stat;
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
     {
         cstring* srcs = shaderSrcVec.data();
@@ -364,7 +364,7 @@ bool GLEAM_Pipeline::attach(const GLEAM_Shader &shader,
         CGL33::ShaderAttach(m_handle,shader.m_handle);
         return true;
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
     {
         if(m_handle==0)
@@ -403,7 +403,7 @@ bool GLEAM_Pipeline::assemble()
         }
         return stat;
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
     {
         bool stat = CGL43::PipelineValidate(m_handle);
@@ -425,7 +425,7 @@ void GLEAM_Pipeline::bind() const
 {
     if(!GLEAM_FEATURES.separable_programs)
         CGL33::ProgramUse(m_handle);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
         CGL43::PipelineBind(m_handle);
 #endif
@@ -435,7 +435,7 @@ void GLEAM_Pipeline::unbind() const
 {
     if(!GLEAM_FEATURES.separable_programs)
         CGL33::ProgramUse(0);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
         CGL43::PipelineBind(0);
 #endif
@@ -445,7 +445,7 @@ void GLEAM_Pipeline::dealloc()
 {
     if(!GLEAM_FEATURES.separable_programs)
         CGL33::ProgramFree(m_handle);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs)
         CGL43::PipelineFree(m_handle);
 #endif
@@ -488,13 +488,15 @@ STATICINLINE bool translate_sampler_type(
         if(!GLEAM_FEATURES.gles20)
             switch(m_flags & SizeMask_f)
             {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
             case S3:
                 samplerType = Texture::T3D;
                 return true;
             case S2A:
                 samplerType = Texture::T2DArray;
                 return true;
+#endif
+#if GL_VERSION_VERIFY(0x330, 0x320)
             case SCubeA:
                 samplerType = Texture::CubemapArray;
                 return true;
@@ -579,7 +581,7 @@ void GLEAM_ShaderUniformState::clear()
     m_uniforms.clear();
 }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
 STATICINLINE void ProgramInputGet(CGhnd hnd, ShaderStage stages,
                                   CGenum type,
                                   Vector<GLEAM_ProgramParameter>* params)
@@ -705,7 +707,7 @@ void GetShaderUniforms(const GLEAM_Pipeline &pipeline,
             delete[] sizes;
         }
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else if(GLEAM_FEATURES.separable_programs){
 
         enum GL_PROP_IDX

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_shader_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_shader_rhi.cpp
@@ -341,7 +341,7 @@ void GLEAM_Shader::dealloc()
         if(m_handle!=0)
             CGL33::ShaderFree(m_handle);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x410, 0x300)
     else if(GLEAM_FEATURES.separable_programs)
     {
         if(m_handle!=0)
@@ -814,7 +814,7 @@ void GLEAM_PipelineDumper::dump(cstring out)
     if(GLEAM_FEATURES.gles20)
         return;
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
     int32* bin_fmts = &GLEAM_API_INSTANCE_DATA->GL_CACHED
             .NUM_PROGRAM_BINARY_FORMATS;
     if(*bin_fmts == -1)

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
@@ -98,7 +98,7 @@ void GLEAM_VertDescriptor::dealloc()
 void GLEAM_VertDescriptor::addAttribute(const GLEAM_VertAttribute& attr)
 {
     m_attributes.push_back(attr);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     if(!GLEAM_FEATURES.gles20)
     {
 #if defined(COFFEE_GLEAM_DESKTOP)
@@ -153,7 +153,7 @@ void GLEAM_VertDescriptor::bindBuffer(uint32 binding, GLEAM_ArrayBuffer& buf)
     {
         m_bufferMapping.insert({binding, buf});
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     else
     {
 #if defined(COFFEE_GLEAM_DESKTOP)

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
@@ -43,7 +43,7 @@ static void vao_apply_buffer(
         if(binding == attr.bufferAssociation())
         {
             CGL33::VAOEnableAttrib(attr.index());
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
             bool use_integer = IsIntegerType(attr.type());
 
             if(use_integer && !(attr.m_flags & GLEAM_API::AttributePacked) &&
@@ -66,7 +66,7 @@ static void vao_apply_buffer(
                     attr.bufferOffset() + attr.offset() +
                         vertexOffset * attr.stride());
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
             if(attr.instanced())
                 CGL33::VAODivisor(attr.index(), 1);
 #endif
@@ -75,12 +75,11 @@ static void vao_apply_buffer(
 
 void GLEAM_VertDescriptor::alloc()
 {
-#if !defined(COFFEE_ONLY_GLES20)
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
     if(GLEAM_FEATURES.direct_state)
         CGL45::VAOAlloc(m_handle);
     else
-#endif
+#elif GL_VERSION_VERIFY(0x300, 0x300)
         if(!GLEAM_FEATURES.gles20)
         CGL33::VAOAlloc(m_handle);
 #endif
@@ -88,7 +87,7 @@ void GLEAM_VertDescriptor::alloc()
 
 void GLEAM_VertDescriptor::dealloc()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(!GLEAM_FEATURES.gles20)
         CGL33::VAOFree(m_handle);
     m_handle = 0;
@@ -101,7 +100,7 @@ void GLEAM_VertDescriptor::addAttribute(const GLEAM_VertAttribute& attr)
 #if GL_VERSION_VERIFY(0x330, 0x320)
     if(!GLEAM_FEATURES.gles20)
     {
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
         if(GLEAM_FEATURES.direct_state)
         {
             CGL45::VAOEnableAttrib(m_handle, attr.index());
@@ -156,12 +155,12 @@ void GLEAM_VertDescriptor::bindBuffer(uint32 binding, GLEAM_ArrayBuffer& buf)
 #if GL_VERSION_VERIFY(0x330, 0x320)
     else
     {
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
         if(!GLEAM_FEATURES.direct_state)
 #endif
             CGL43::VAOBind(m_handle);
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
         if(GLEAM_FEATURES.direct_state)
         {
             for(GLEAM_VertAttribute const& attr : m_attributes)
@@ -209,7 +208,7 @@ void GLEAM_VertDescriptor::setIndexBuffer(const GLEAM_ElementBuffer* buffer)
 {
     m_ibuffer = buffer;
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x450, GL_VERSION_NONE)
     if(GLEAM_FEATURES.vertex_format && GLEAM_FEATURES.direct_state)
         CGL45::VAOElementBuffer(m_handle, buffer->m_handle);
 #endif
@@ -217,7 +216,7 @@ void GLEAM_VertDescriptor::setIndexBuffer(const GLEAM_ElementBuffer* buffer)
 
 void GLEAM_VertDescriptor::bind(u32 vertexOffset)
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(!GLEAM_FEATURES.gles20)
     {
         CGL33::VAOBind(m_handle);
@@ -237,7 +236,7 @@ void GLEAM_VertDescriptor::bind(u32 vertexOffset)
 
 void GLEAM_VertDescriptor::unbind()
 {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     if(!GLEAM_FEATURES.gles20)
         CGL33::VAOBind(0);
     else

--- a/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
+++ b/coffee/graphics/apis/gleam/private/rhi/gleam_vertex_rhi.cpp
@@ -79,9 +79,10 @@ void GLEAM_VertDescriptor::alloc()
     if(GLEAM_FEATURES.direct_state)
         CGL45::VAOAlloc(m_handle);
     else
-#elif GL_VERSION_VERIFY(0x300, 0x300)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         if(!GLEAM_FEATURES.gles20)
         CGL33::VAOAlloc(m_handle);
+#endif
 #endif
 }
 

--- a/coffee/sdl2/private/graphics/csdl2_gl_renderer.cpp
+++ b/coffee/sdl2/private/graphics/csdl2_gl_renderer.cpp
@@ -92,6 +92,7 @@ bool SDL2GLRenderer::contextInit(const GLProperties&,CString* err)
     else
     {
         CString m_err = cStringFormat("Failed to create SDL2 OpenGL context: {0}",SDL_GetError());
+        cDebug("{0}", m_err);
         if(err)
             *err = m_err;
         return false;

--- a/coffee/windowing/private/binding/glad/conversion.h
+++ b/coffee/windowing/private/binding/glad/conversion.h
@@ -2,10 +2,11 @@
 
 #include <coffee/core/types/edef/dbgenum.h>
 #include <coffee/graphics/apis/gleam/levels/shared/gl_shared_include.h>
+#include <coffee/graphics/apis/gleam/levels/shared/gl_shared_types.h>
 
 namespace Coffee{
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
 DebugType gl_converttype(GLuint type)
 {
     switch(type)

--- a/coffee/windowing/private/binding/glad/gleamrenderer.cpp
+++ b/coffee/windowing/private/binding/glad/gleamrenderer.cpp
@@ -97,9 +97,12 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
 
     cVerbose(8, GLR_API "Attempting to load version: {0}",p.version);
 
+    /* When rendering with GLES or EGL, we need a procloader most likely */
 #if !defined(COFFEE_GLEAM_DESKTOP) || defined(COFFEE_USE_MAEMO_EGL)
 
+    /* If GLES functions are linked, skip this */
 #if !defined(COFFEE_LINKED_GLES)
+    /* Otherwise, pick a procloader based on the current windowing API */
 #if defined(COFFEE_USE_LINUX_GLX)
     GLADloadproc procload = (GLADloadproc)glXGetProcAddress;
 #elif defined(COFFEE_USE_MAEMO_EGL)
@@ -116,7 +119,7 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
     Profiler::DeepPushContext(GLR_API "Loading GLAD binding");
     if(!(p.flags & GLProperties::Flags::GLES))
     {
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         const static CGLVersion v33(3,3);
         const static CGLVersion v43(4,3);
         const static CGLVersion v45(4,5);
@@ -134,9 +137,9 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
         }
 #endif
     }else{
-#ifndef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(GL_VERSION_NONE, 0x200)
         const static CGLVersion v20es(2,0);
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(GL_VERSION_NONE, 0x300)
         const static CGLVersion v30es(3,0);
         const static CGLVersion v32es(3,2);
 #endif

--- a/coffee/windowing/private/binding/glad/gleamrenderer.cpp
+++ b/coffee/windowing/private/binding/glad/gleamrenderer.cpp
@@ -36,7 +36,7 @@ GLeamRenderer::~GLeamRenderer()
 {
 }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
 void gleamcallback(
         GLenum src, GLenum type,GLuint id,GLenum sev,
         GLsizei,const GLchar* msg,
@@ -141,11 +141,14 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
         const static CGLVersion v32es(3,2);
 #endif
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if !defined(COFFEE_LINKED_GLES)
+#if GL_VERSION_VERIFY(0x0, 0x320)
         if(p.version>=v32es)
         {
             status = CGL::CGLES32::LoadBinding(m_app->glContext(),procload);
         }else
+#endif
+#if GL_VERSION_VERIFY(0x0, 0x300)
         if(p.version==v30es)
         {
             status = CGL::CGLES30::LoadBinding(m_app->glContext(),procload);
@@ -153,13 +156,11 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
 #endif
         if(p.version==v20es)
         {
-#if !defined(COFFEE_LINKED_GLES)
             status = CGL::CGLES20::LoadBinding(m_app->glContext(),procload);
-#else
-            cVerbose(7, "Checking OpenGL ES 2.0 functions...");
-            status = CGL::CGLES20::LoadBinding(m_app->glContext(),nullptr);
-#endif
         }
+#else
+        status = true;
+#endif
 #endif
     }
     Profiler::DeepPopContext();
@@ -293,7 +294,7 @@ bool GLeamRenderer::bindingPostInit(const GLProperties& p, CString *err)
 
     if(GL::DebuggingSupported())
     {
-#if !defined(COFFEE_WINDOWS) && !defined(COFFEE_ONLY_GLES20)
+#if !defined(COFFEE_WINDOWS) && GL_VERSION_VERIFY(0x330, 0x320)
         DProfContext b(GLR_API "Configuring GL context debugging");
         GL::Debug::SetDebugMode(true);
         GL::Debug::DebugSetCallback(gleamcallback,this);

--- a/include/coffee/core/base/renderer/eventapplication.h
+++ b/include/coffee/core/base/renderer/eventapplication.h
@@ -424,14 +424,7 @@ class EventApplication : public InputApplication
 
         using namespace CfEventFunctions;
 
-#if defined(COFFEE_USE_APPLE_GLKIT) || \
-    defined(COFFEE_USE_ANDROID_NATIVEWIN) || defined(COFFEE_EMSCRIPTEN)
-        auto stored_event_data = new UqPtr<ELD>();
-        auto& local_event_data = *stored_event_data;
-        local_event_data = std::move(ev);
-#else
-        auto& local_event_data = ev;
-#endif
+        static UqPtr<ELD> local_event_data = std::move(ev);
 
         local_event_data->visual   = visual;
         coffee_event_handling_data = local_event_data.get();

--- a/include/coffee/core/plat/environment/emscripten/sysinfo.h
+++ b/include/coffee/core/plat/environment/emscripten/sysinfo.h
@@ -5,6 +5,9 @@
 #if defined(COFFEE_EMSCRIPTEN)
 
 #include "../sysinfo_def.h"
+#include <malloc.h>
+
+extern "C" char* get_user_agent();
 
 namespace Coffee {
 namespace Environment{
@@ -13,6 +16,17 @@ namespace Emscripten {
 struct EmSysInfo : SysInfoDef
 {
     static CString GetSystemVersion();
+
+    STATICINLINE HWDeviceInfo DeviceName()
+    {
+        cstring_w userAgentRaw = get_user_agent();
+        if(!userAgentRaw)
+            return HWDeviceInfo("Generic", "Browser", "1.0");
+
+        CString userAgent = userAgentRaw;
+        free(userAgentRaw);
+        return HWDeviceInfo(userAgent, "", "1.0");
+    }
 };
 struct EmPowerInfo : PowerInfoDef
 {

--- a/include/coffee/core/plat/memory/cmd_unixterm.h
+++ b/include/coffee/core/plat/memory/cmd_unixterm.h
@@ -13,8 +13,12 @@ struct UnixTerm : CmdInterface::BasicTerm
 {
     static bool Interactive()
     {
+#if defined(COFFEE_LINUX)
+        return isatty(fileno(stdout)) && isatty(fileno(stderr));
+#else
         //TODO: Find way of detecting interactive session
         return false;
+#endif
     }
 
     static void ClearScreen()

--- a/include/coffee/core/plat/plat_quirks_toggling.h
+++ b/include/coffee/core/plat/plat_quirks_toggling.h
@@ -222,7 +222,7 @@
 #if defined(COFFEE_EMSCRIPTEN)
 #define COFFEE_WEBGL
 #define COFFEE_LINKED_GLES
-#define COFFEE_LINKED_GLES30
+#define COFFEE_LINKED_GLES20
 #endif
 
 /*

--- a/include/coffee/core/plat/plat_quirks_toggling.h
+++ b/include/coffee/core/plat/plat_quirks_toggling.h
@@ -214,9 +214,15 @@
 #endif
 
 #if defined(COFFEE_APPLE_MOBILE)\
-    || defined(COFFEE_GLES20_MODE) || defined(COFFEE_EMSCRIPTEN)
+    || defined(COFFEE_GLES20_MODE)// || defined(COFFEE_EMSCRIPTEN)
 #define COFFEE_LINKED_GLES
 #define COFFEE_ONLY_GLES20
+#endif
+
+#if defined(COFFEE_EMSCRIPTEN)
+#define COFFEE_WEBGL
+#define COFFEE_LINKED_GLES
+#define COFFEE_LINKED_GLES30
 #endif
 
 /*

--- a/include/coffee/graphics/apis/gleam/levels/es/gles32.h
+++ b/include/coffee/graphics/apis/gleam/levels/es/gles32.h
@@ -7,18 +7,23 @@
 #include "../shared/xfb/arb_xf2.h"
 
 #include "../shared/draw/drawing_43.h"
+
+#if GL_VERSION_VERIFY(0x330, 0x320)
 #include "../shared/draw/arb_tessellation_shader.h"
 #include "../shared/draw/arb_compute_shader.h"
 
 #include "../shared/constructors/arb_separate_shader_programs.h"
 #include "../shared/shaders/arb_program_interface_query.h"
 #include "../shared/shaders/arb_separate_shader_programs.h"
-#include "../shared/shaders/arb_es2_compatibility.h"
-#include "../shared/shaders/arb_get_program_binary.h"
-
 #include "../shared/vertex/arb_vertex_attrib_binding.h"
 
 #include "../shared/framebuffers/arb_framebuffer_no_attachments.h"
+#endif
+
+#include "../shared/shaders/arb_es2_compatibility.h"
+#include "../shared/shaders/arb_get_program_binary.h"
+
+
 
 namespace Coffee{
 namespace CGL{
@@ -35,20 +40,28 @@ struct CGLES32 :
 
         CGL_TextureStorage,
 
+        #if GL_VERSION_VERIFY(0xFFFF, 0x320)
         CGL_SeparableShaderPrograms,
 
         CGL_SeparableShaderPrograms_Allocators,
         CGL_XF2_Allocators,
+        #endif
 
+        #if GL_VERSION_VERIFY(0xFFFF, 0x320)
         CGL_TessellationShader,
         CGL_ComputeShader,
         CGL_Drawing_43,
+        #endif
 
         CGL_ES2Compatibility,
+        #if GL_VERSION_VERIFY(0xFFFF, 0x320)
         CGL_ProgramInterfaceQuery,
+        #endif
         CGL_GetProgramBinary,
 
+        #if GL_VERSION_VERIFY(0xFFFF, 0x320)
         CGL_VertexAttribBinding<GLESVER_32>,
+        #endif
 
         CGL_XF2
 {
@@ -71,7 +84,11 @@ struct CGLES32 :
         if(!CGLES30::LoadBinding(ctxt,fun))
             return false;
 
+#if defined(COFFEE_LINKED_GLES32)
         return (bool)glVertexAttribFormat;
+#else
+        return true;
+#endif
     }
 
     STATICINLINE void ViewportSet(uint32, CRectF& view)
@@ -79,8 +96,10 @@ struct CGLES32 :
         ViewportSet(view.convert<int64>());
     }
 
+#if defined(COFFEE_LINKED_GLES32)
     STATICINLINE void BlendFunci(uint32 i, CGenum v1,CGenum v2)
     {glBlendFunci(i,v1,v2);}
+#endif
 
     /* Stubbing this to avoid compilation errors */
     template<typename... T>

--- a/include/coffee/graphics/apis/gleam/levels/gl_shared.h
+++ b/include/coffee/graphics/apis/gleam/levels/gl_shared.h
@@ -78,7 +78,7 @@ struct CGL_Shared_Functions
     STATICINLINE
     void ClearBufferiv(const int32* d)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         glClearBufferiv(GL_STENCIL,0,d);
 #else
         ClearStencil(*d);
@@ -88,7 +88,7 @@ struct CGL_Shared_Functions
     STATICINLINE
     void ClearBufferfv(const scalar* d)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         glClearBufferfv(GL_DEPTH,0,d);
 #else
         ClearDepth(*d);
@@ -98,7 +98,7 @@ struct CGL_Shared_Functions
     STATICINLINE
     void ClearBufferfv(bool,int32 i,const CVec4& d)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         glClearBufferfv(GL_COLOR,i,(scalar*)&d);
 #else
         C_UNUSED(i);
@@ -109,7 +109,7 @@ struct CGL_Shared_Functions
     STATICINLINE
     void ClearBufferfi(scalar d,int32 s)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         glClearBufferfi(GL_DEPTH_STENCIL,0,d,s);
 #else
         ClearBufferiv(&s);
@@ -136,7 +136,7 @@ struct CGL_Shared_Functions
     STATICINLINE
     void DepthSet(ZField64 const& d)
     {
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glDepthRange(d.near_,d.far_);
 #else
         glDepthRangef(d.near_,d.far_);
@@ -171,7 +171,7 @@ struct CGL_Shared_Functions
         C_UNUSED(f1);
         C_UNUSED(f2);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glPolygonMode(to_enum(f1),to_enum(f2));
 #endif
     }
@@ -183,7 +183,7 @@ struct CGL_Shared_Functions
         C_UNUSED(f);
         C_UNUSED(d);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glPointParameteriv(f,d);
 #endif
     }
@@ -195,7 +195,7 @@ struct CGL_Shared_Functions
         C_UNUSED(f);
         C_UNUSED(d);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glPointParameterfv(f,d);
 #endif
     }
@@ -206,7 +206,7 @@ struct CGL_Shared_Functions
     {
         C_UNUSED(f);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glPointSize(f);
 #endif
     }
@@ -235,7 +235,7 @@ struct CGL_Shared_Functions
     {
         C_UNUSED(op);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glColorMask(op.r,op.g,op.b,op.a);
 #endif
     }
@@ -246,7 +246,7 @@ struct CGL_Shared_Functions
         C_UNUSED(i);
         C_UNUSED(op);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glColorMaski(i,op.r,op.g,op.b,op.a);
 #endif
     }
@@ -257,7 +257,7 @@ struct CGL_Shared_Functions
     {
         C_UNUSED(op);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         glLogicOp(to_enum(op));
 #endif
     }
@@ -268,8 +268,7 @@ struct CGL_Shared_Functions
      * \brief Check if platform supports any kind of GL debugging. If this returns true, there should be a valid implementation.
      * \return
      */
-#if (!defined(COFFEE_ONLY_GLES20) && defined(COFFEE_LINKED_GLES32)) ||\
-    defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x430, 0x320)
     bool DebuggingSupported()
     {return Debug::CheckExtensionSupported("GL_KHR_debug") && glDebugMessageCallback;}
 #else

--- a/include/coffee/graphics/apis/gleam/levels/gl_shared.h
+++ b/include/coffee/graphics/apis/gleam/levels/gl_shared.h
@@ -52,11 +52,11 @@ struct CGL_Shared_Functions
     STATICINLINE
     void Disable(Feature e,uint32 o = 0){glDisable(to_enum(e,o));}
 
-#if !defined(COFFEE_ONLY_GLES20)
-    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_30)
+#if GL_VERSION_VERIFY(0x330, 0x320)
+    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_32)
     STATICINLINE
     void Enablei(Feature e,uint32 i,uint32 o = 0){glEnablei(to_enum(e,o),i);}
-    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_30)
+    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_32)
     STATICINLINE
     void Disablei(Feature e,uint32 i,uint32 o = 0){glDisablei(to_enum(e,o),i);}
 #endif
@@ -216,8 +216,8 @@ struct CGL_Shared_Functions
     STATICINLINE
     void SampleCoverage(scalar f,bool d){glSampleCoverage(f,(d) ? GL_TRUE : GL_FALSE);}
 
-#if !defined(COFFEE_ONLY_GLES20)
-    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_30)
+#if GL_VERSION_VERIFY(0x330, 0x310)
+    GL_VERSION_REQ_COMBO(GLVER_33, GLESVER_31)
     STATICINLINE
     void SampleMaski(uint32 d,CGflag f){glSampleMaski(d,f);}
 #endif
@@ -268,7 +268,8 @@ struct CGL_Shared_Functions
      * \brief Check if platform supports any kind of GL debugging. If this returns true, there should be a valid implementation.
      * \return
      */
-#if !defined(COFFEE_ONLY_GLES20)
+#if (!defined(COFFEE_ONLY_GLES20) && defined(COFFEE_LINKED_GLES32)) ||\
+    defined(COFFEE_GLEAM_DESKTOP)
     bool DebuggingSupported()
     {return Debug::CheckExtensionSupported("GL_KHR_debug") && glDebugMessageCallback;}
 #else

--- a/include/coffee/graphics/apis/gleam/levels/gl_shared_util.h
+++ b/include/coffee/graphics/apis/gleam/levels/gl_shared_util.h
@@ -3,7 +3,7 @@
 #include <coffee/CImage>
 #include <coffee/core/CFiles>
 
-#include "shared/gl_shared_include.h"
+#include "shared/gl_shared_types.h"
 
 namespace Coffee{
 namespace CGL{
@@ -25,7 +25,7 @@ struct CGLUtil
         C_USED(l);
         C_USED(fn);
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
 
         CSize tsize;
         GL::TexGetLevelParameteriv(t,l,GL_TEXTURE_WIDTH,&tsize.w);

--- a/include/coffee/graphics/apis/gleam/levels/gl_to_enum.inl
+++ b/include/coffee/graphics/apis/gleam/levels/gl_to_enum.inl
@@ -14,7 +14,7 @@ inline CGenum to_enum(
 {
     switch(s)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case Severity::High:
         return GL_DEBUG_SEVERITY_HIGH;
     case Severity::Medium:
@@ -34,7 +34,7 @@ inline CGenum to_enum(
 {
     switch(t)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case DebugType::Compatibility:
         return GL_DEBUG_TYPE_PORTABILITY;
     case DebugType::Compliance:
@@ -64,7 +64,7 @@ inline CGenum to_enum(
     CGenum type;
     switch(t)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case Object::Shader:
         type = GL_SHADER;
         break;
@@ -138,7 +138,7 @@ inline CGenum to_enum(
     case Feature::ClipDist:
         return GL_CLIP_DISTANCE0+((offset>7) ? 7 : offset);
 #endif
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case Feature::DebugOutput:
         return GL_DEBUG_OUTPUT;
     case Feature::DebugOutputSync:
@@ -585,20 +585,18 @@ inline CGenum to_enum1(
     {
     case ShaderStage::Vertex:
         return GL_VERTEX_SHADER;
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case ShaderStage::TessControl:
         return GL_TESS_CONTROL_SHADER;
     case ShaderStage::TessEval:
         return GL_TESS_EVALUATION_SHADER;
     case ShaderStage::Geometry:
         return GL_GEOMETRY_SHADER;
-#endif
-    case ShaderStage::Fragment:
-        return GL_FRAGMENT_SHADER;
-#if !defined(COFFEE_ONLY_GLES20)
     case ShaderStage::Compute:
         return GL_COMPUTE_SHADER;
 #endif
+    case ShaderStage::Fragment:
+        return GL_FRAGMENT_SHADER;
     default:
         return GL_NONE;
     }
@@ -611,7 +609,7 @@ inline CGenum to_enum2(
 
     CGenum o = 0;
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     if(feval(f&ShaderStage::Vertex))
         o |= GL_VERTEX_SHADER_BIT;
     if(feval(f&ShaderStage::TessControl))
@@ -709,7 +707,7 @@ inline CGenum to_enum(Texture f)
     return (CGenum)f;
 }
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x330, GL_VERSION_NONE)
 inline CGenum to_enum(LogicOp op)
 {
     if(feval(op&(LogicOp::COPY)))
@@ -1182,8 +1180,15 @@ inline uint32 to_enum_shtype(CGenum f)
     case GL_SAMPLER_CUBE:
         return sdt_sampf<SCube>::value;
 #if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     case GL_SAMPLER_CUBE_MAP_ARRAY:
         return sdt_sampf<SCubeA>::value;
+    case GL_INT_SAMPLER_CUBE_MAP_ARRAY:
+        return sdt_samp<Int_t,SCubeA>::value;
+    case GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY:
+        return sdt_samp<UInt_t,SCubeA>::value;
+#endif
+
     case GL_SAMPLER_3D:
         return sdt_sampf<S3>::value;
     case GL_SAMPLER_2D_ARRAY:
@@ -1197,8 +1202,6 @@ inline uint32 to_enum_shtype(CGenum f)
         return sdt_samp<UInt_t,S2A>::value;
     case GL_UNSIGNED_INT_SAMPLER_CUBE:
         return sdt_samp<UInt_t,SCube>::value;
-    case GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY:
-        return sdt_samp<UInt_t,SCubeA>::value;
 
     case GL_INT_SAMPLER_2D:
         return sdt_samp<Int_t,S2>::value;
@@ -1208,9 +1211,6 @@ inline uint32 to_enum_shtype(CGenum f)
         return sdt_samp<Int_t,S2A>::value;
     case GL_INT_SAMPLER_CUBE:
         return sdt_samp<Int_t,SCube>::value;
-    case GL_INT_SAMPLER_CUBE_MAP_ARRAY:
-        return sdt_samp<Int_t,SCubeA>::value;
-        break;
 #endif
 
     case GL_FLOAT:

--- a/include/coffee/graphics/apis/gleam/levels/shared/buffers/old_buffers.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/buffers/old_buffers.h
@@ -37,7 +37,7 @@ struct CGL_Old_Buffers
         glCopyBufferSubData(to_enum(t1), to_enum(t2), off1, off2, sz);
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     GL_VERSION_REQ_COMBO(GLVER_30, GLESVER_30)
     STATICINLINE void BufBindRange(
         BufType t, uint32 i, CGhnd b, ptroff off, ptroff sz)
@@ -64,7 +64,8 @@ struct CGL_Old_Buffers
     {
         glGetBufferParameteriv(to_enum(t), p, v);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+
+#if GL_VERSION_VERIFY(0x300, 0x300)
     GL_VERSION_REQ_COMBO(GLVER_32, GLESVER_30)
     STATICINLINE void BufGetParameterLLv(BufType t, CGenum p, i64* v)
     {

--- a/include/coffee/graphics/apis/gleam/levels/shared/constructors/oldstyle.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/constructors/oldstyle.h
@@ -56,7 +56,7 @@ struct CGL_Old_Constructors
         return true;
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE bool SamplerAlloc(Span<CGhnd> const& handles)
     {
         glGenSamplers(handles.elements, handles.data);
@@ -117,7 +117,7 @@ struct CGL_Old_Constructors
         return true;
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE bool FenceFree(Span<GLsync> const& handles)
     {
         for(uint32 i = 0; i < handles.elements; i++)

--- a/include/coffee/graphics/apis/gleam/levels/shared/draw/arb_tessellation_shader.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/draw/arb_tessellation_shader.h
@@ -14,7 +14,7 @@ struct CGL_TessellationShader
     STATICINLINE void PatchParameteri(PatchProperty p,int32 v)
     {glPatchParameteri(to_enum(p),v);}
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x400, GL_VERSION_NONE)
     STATICINLINE void PatchParameterfv(PatchProperty p,const scalar* v)
     {glPatchParameterfv(to_enum(p),v);}
 #endif

--- a/include/coffee/graphics/apis/gleam/levels/shared/draw/basic.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/draw/basic.h
@@ -25,18 +25,21 @@ struct CGL_Basic_Draw
             DrwMd const& p,u32 c,TypeEnum t,u64 off)
     {glDrawElements(to_enum(p),c,to_enum(t),(void*)off);}
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     STATICINLINE void DrawElementsBaseVertex(
             DrwMd const& p, u32 c, TypeEnum t, u64 off, i32 voff)
     {glDrawElementsBaseVertex(to_enum(p), c, to_enum(t), (void*)off, voff);}
-    STATICINLINE void DrawElementsInstanced(
-            DrwMd const& p,u32 c,TypeEnum t,uint64 off,u64 pc)
-    {glDrawElementsInstanced(to_enum(p),c,to_enum(t),(void*)off,pc);}
-
     STATICINLINE void DrawElementInstancedBaseVertex(
             DrwMd const& p,u32 c,TypeEnum t,u64 off,u64 pc,i32 voff)
     {glDrawElementsInstancedBaseVertex(
                     to_enum(p), c, to_enum(t), (void*)off, pc, voff);}
+#endif
+
+    STATICINLINE void DrawElementsInstanced(
+            DrwMd const& p,u32 c,TypeEnum t,uint64 off,u64 pc)
+    {glDrawElementsInstanced(to_enum(p),c,to_enum(t),(void*)off,pc);}
+
 
     STATICINLINE void DrawRangeElements(
             DrwMd const& p,u32 f,u32 e,i32 c,TypeEnum t,i64 off)

--- a/include/coffee/graphics/apis/gleam/levels/shared/draw/basic.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/draw/basic.h
@@ -14,7 +14,7 @@ struct CGL_Basic_Draw
             DrwMd const& p,i32 f,u64 c)
     {glDrawArrays(to_enum(p),f,c);}
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void DrawArraysInstanced(
             DrwMd const& p,i32 f, u32 c,u32 ic)
     {glDrawArraysInstanced(to_enum(p),f,c,ic);}

--- a/include/coffee/graphics/apis/gleam/levels/shared/draw/drawing_43.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/draw/drawing_43.h
@@ -62,7 +62,7 @@ struct CGL_Drawing_43
             DrwMd c,uint32 f,uint32 e,uint32 vc,TypeEnum d,uint64 off)
     {glDrawRangeElements(to_enum(c),f,e,vc,to_enum(d),(c_cptr)off);}
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x420, GL_VERSION_NONE)
     /*!
      * \brief DrawElementsInstancedBaseInstance
      * \param p Primitive type
@@ -103,7 +103,9 @@ struct CGL_Drawing_43
     STATICINLINE void DrawArraysInstancedBaseInstance(DrwMd c,int32 vf,
                                                 uint32 vc,uint32 ic,uint32 bi)
     {glDrawArraysInstancedBaseInstance(to_enum(c),vf,vc,ic,bi);}
+#endif
 
+#if GL_VERSION_VERIFY(0x400, GL_VERSION_NONE)
     /*!
      * \brief DrawXF
      * \param p Primitive type
@@ -121,7 +123,9 @@ struct CGL_Drawing_43
      */
     STATICINLINE void DrawXFStream(DrwMd c,CGhnd h,uint32 s)
     {glDrawTransformFeedbackStream(to_enum(c),h,s);}
+#endif
 
+#if GL_VERSION_VERIFY(0x420, GL_VERSION_NONE)
     /*!
      * \brief DrawXFInstanced
      * \param p Primitive type

--- a/include/coffee/graphics/apis/gleam/levels/shared/draw/drawing_43.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/draw/drawing_43.h
@@ -10,6 +10,7 @@ namespace CGL{
 
 struct CGL_Drawing_43
 {
+#if GL_VERSION_VERIFY(0x330, 0x320)
     /*!
      * \brief DrawArraysIndirect
      * \param p Primitive type
@@ -32,19 +33,6 @@ struct CGL_Drawing_43
     {glDrawElementsIndirect(to_enum(c),to_enum(d),(c_cptr)off);}
 
     /*!
-     * \brief DrawRangeElements
-     * \param p Primitive type
-     * \param c Primitive creation method
-     * \param f First element in range to draw
-     * \param e Last element in range to draw
-     * \param vc Number of elements to draw
-     * \param d Element data type
-     * \param off Offset into index buffer
-     */
-    STATICINLINE void DrawRangeElements(
-            DrwMd c,uint32 f,uint32 e,uint32 vc,TypeEnum d,uint64 off)
-    {glDrawRangeElements(to_enum(c),f,e,vc,to_enum(d),(c_cptr)off);}
-    /*!
      * \brief DrawRangeElementsBaseVertex
      * \param p Primitive type
      * \param c Primitive creation method
@@ -58,6 +46,21 @@ struct CGL_Drawing_43
     STATICINLINE void DrawRangeElementsBaseVertex(
             DrwMd c,uint32 f,uint32 e,uint32 vc,TypeEnum d,uint64 off,int32 bv)
     {glDrawRangeElementsBaseVertex(to_enum(c),f,e,vc,to_enum(d),(c_cptr)off,bv);}
+#endif
+
+    /*!
+     * \brief DrawRangeElements
+     * \param p Primitive type
+     * \param c Primitive creation method
+     * \param f First element in range to draw
+     * \param e Last element in range to draw
+     * \param vc Number of elements to draw
+     * \param d Element data type
+     * \param off Offset into index buffer
+     */
+    STATICINLINE void DrawRangeElements(
+            DrwMd c,uint32 f,uint32 e,uint32 vc,TypeEnum d,uint64 off)
+    {glDrawRangeElements(to_enum(c),f,e,vc,to_enum(d),(c_cptr)off);}
 
 #ifdef COFFEE_GLEAM_DESKTOP
     /*!

--- a/include/coffee/graphics/apis/gleam/levels/shared/framebuffers/old_framebuffers.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/framebuffers/old_framebuffers.h
@@ -52,7 +52,7 @@ struct CGL_Old_Framebuffers
         glFramebufferRenderbuffer(to_enum(t), att, GL_RENDERBUFFER, h);
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     /* Blit */
     GL_VERSION_REQ_COMBO(GLVER_30, GLESVER_30)
     STATICINLINE void FBBlit(
@@ -103,7 +103,7 @@ struct CGL_Old_Framebuffers
 
         glRenderbufferStorage(GL_RENDERBUFFER, fmt, w, h);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void RBufStorageMS(
         PixelFormat ifmt, uint32 samples, uint32 w, uint32 h)
     {
@@ -125,7 +125,7 @@ struct CGL_Old_Framebuffers
 
         CSize out = {};
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         using Tex = CGL_Old_Textures<CGhnd, CGenum, Texture, CompFlags>;
 
         int32 tmp = 0;

--- a/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_debug.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_debug.h
@@ -147,7 +147,7 @@ struct CGL_Shared_Debug
         C_UNUSED(s);
         C_UNUSED(enabled);
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glDebugMessageControl(
                     GL_DONT_CARE,GL_DONT_CARE,
                     to_enum(s),0,nullptr,
@@ -161,7 +161,7 @@ struct CGL_Shared_Debug
         C_UNUSED(h);
         C_UNUSED(s);
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glObjectLabel(to_enum(t),h,-1,s);
 #endif
     }
@@ -171,13 +171,13 @@ struct CGL_Shared_Debug
         C_UNUSED(n);
         C_UNUSED(id);
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION,id,-1,n);
 #endif
     }
     STATICINLINE void UnsetDebugGroup()
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glPopDebugGroup();
 #endif
     }
@@ -188,7 +188,7 @@ struct CGL_Shared_Debug
         C_UNUSED(t);
         C_UNUSED(n);
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION,
                              to_enum(t),0,
                              to_enum(s),
@@ -201,7 +201,7 @@ struct CGL_Shared_Debug
         C_UNUSED(c);
         C_UNUSED(param);
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
         glDebugMessageCallback(c,param);
 #endif
     }
@@ -383,12 +383,15 @@ struct CGL_Shared_Debug
     STATICINLINE
     bool IsXF(CGhnd h){return glIsTransformFeedback(h)==GL_TRUE;}
 
+#if GL_VERSION_VERIFY(0x330, 0x310)
     STATICINLINE
     bool IsPipeline(CGhnd h){return glIsProgramPipeline(h)==GL_TRUE;}
 
     /* IsEnabled */
     STATICINLINE
     bool IsEnabledi(Feature f,int32 i){return glIsEnabledi(to_enum(f),i)==GL_TRUE;}
+#endif
+
 #endif
 };
 

--- a/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_debug.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_debug.h
@@ -262,7 +262,7 @@ struct CGL_Shared_Debug
 
     STATICINLINE bool InternalFormatSupport(Texture, PixelFormat)
     {
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         return true;
 #else
         return false;
@@ -282,7 +282,7 @@ struct CGL_Shared_Debug
     /* GetString */
 
     STATICINLINE cstring GetString(CGenum e){return C_RCAST<cstring>(glGetString(e));}
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE cstring GetStringi(CGenum e,uint32 i){return (cstring)glGetStringi(e,i);}
 #endif
 
@@ -305,7 +305,7 @@ struct CGL_Shared_Debug
         glGetIntegerv(e,&i);
         return i;
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE int64 GetIntegerLL(CGenum e)
     {
         int64 i = 0;
@@ -329,7 +329,7 @@ struct CGL_Shared_Debug
     }
 
     /* Get*i_v */
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE int32 GetIntegerI(CGenum e,uint32 i)
     {
         int32 v = 0;
@@ -352,7 +352,7 @@ struct CGL_Shared_Debug
     {
         return glIsBuffer(h)==GL_TRUE;
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE
     bool IsVAO(CGhnd h){return glIsVertexArray(h)==GL_TRUE;}
 #endif
@@ -370,7 +370,7 @@ struct CGL_Shared_Debug
     STATICINLINE
     bool IsTexture(CGhnd h){return glIsTexture(h)==GL_TRUE;}
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE
     bool IsSampler(CGhnd h){return glIsSampler(h)==GL_TRUE;}
 

--- a/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_include.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_include.h
@@ -26,7 +26,12 @@
 #include <glad/glad.h>
 #include <glad/KHR/khrplatform.h>
 
+#define GL_VERSION_BASE_CORE 0xFFFF
+#define GL_VERSION_BASE_ES   0x0
+
 #else
+
+#define GL_VERSION_BASE_CORE 0x0
 
 #if defined(COFFEE_LINKED_GLES)
 
@@ -39,21 +44,38 @@
 // Apple loads the functions from a framework
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
+
+#define GL_VERSION_BASE_ES 0x200
+
 #else
+
+#if defined(COFFEE_LINKED_GLES32)
+#include <GLES3/gl32.h>
+#ifndef GL_VERSION_BASE_ES
+#define GL_VERSION_BASE_ES 0x320
+#endif
+#endif
+#if defined(COFFEE_LINKED_GLES31)
+#include <GLES3/gl31.h>
+#ifndef GL_VERSION_BASE_ES
+#define GL_VERSION_BASE_ES 0x310
+#endif
+#endif
+#if defined(COFFEE_LINKED_GLES30)
+#include <GLES3/gl3.h>
+#ifndef GL_VERSION_BASE_ES
+#define GL_VERSION_BASE_ES 0x300
+#endif
+#endif
 
 // Standard headers for GLES functions
 #include <GLES2/gl2.h>
 
+#ifndef GL_VERSION_BASE_ES
+#define GL_VERSION_BASE_ES 0x200
+#endif
+
 // GLES3.x is optional
-#if defined(COFFEE_LINKED_GLES30)
-#include <GLES3/gl3.h>
-#endif
-#if defined(COFFEE_LINKED_GLES31)
-#include <GLES3/gl31.h>
-#endif
-#if defined(COFFEE_LINKED_GLES32)
-#include <GLES3/gl32.h>
-#endif
 
 #endif
 
@@ -61,6 +83,9 @@
 // Runtime-loaded OpenGL functions
 #include <glad_es/glad.h>
 #include <glad_es/KHR/khrplatform.h>
+
+#define GL_VERSION_BASE_ES 0xFFFF
+
 #endif
 
 #endif

--- a/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_types.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_types.h
@@ -97,6 +97,11 @@ struct gl_version_at_least_ver
         return Debug::CheckExtensionSupported(ext_name);\
     }
 
+#define GL_VERSION_NONE 0xFFFFF
+
+#define GL_VERSION_VERIFY(core_ver, es_ver) \
+    (GL_VERSION_BASE_CORE >= core_ver) || (GL_VERSION_BASE_ES >= es_ver)
+
 /*
  * The above macro is used as such:
  *
@@ -111,10 +116,10 @@ struct gl_version_at_least_ver
 /* Type definitions */
 using CGenum = uint32;
 using CGflag = uint32;
-#if defined(COFFEE_ONLY_GLES20)
-using CGcallback = void(*)();
-#else
+#if GL_VERSION_VERIFY(0x410, 0x320)
 using CGcallback = GLDEBUGPROC;
+#else
+using CGcallback = void(*)();
 #endif
 using CGsync = void*;
 
@@ -330,7 +335,7 @@ enum class Texture
 #else
     T2DArray = GL_TEXTURE_2D_ARRAY,
 #endif
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x320)
     CubemapArray = GL_TEXTURE_CUBE_MAP_ARRAY,
 #endif
 
@@ -398,10 +403,10 @@ enum class QueryT
 
 enum class PatchProperty
 {
-#if defined(COFFEE_ONLY_GLES20)
-    Vertices = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x330, 0x320)
     Vertices = GL_PATCH_VERTICES,
+#else
+    Vertices = GL_NONE,
 #endif
 #ifdef COFFEE_GLEAM_DESKTOP
     DefOuterLevel = GL_PATCH_DEFAULT_OUTER_LEVEL,

--- a/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_types.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/gl_shared_types.h
@@ -6,6 +6,7 @@
 #include <coffee/core/types/edef/enumfun.h>
 #include <coffee/core/types/edef/graphicsenum.h>
 #include <coffee/core/types/tdef/stltypes.h>
+#include <coffee/core/types/tdef/integertypes.h>
 
 namespace Coffee{
 namespace CGL{
@@ -164,12 +165,12 @@ enum class VertexWinding
 
 enum class AttribMode
 {
-#if defined(COFFEE_ONLY_GLES20)
-    Interleaved = GL_NONE,
-    Separate = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     Interleaved = GL_INTERLEAVED_ATTRIBS,
     Separate = GL_SEPARATE_ATTRIBS,
+#else
+    Interleaved = GL_NONE,
+    Separate = GL_NONE,
 #endif
 };
 
@@ -220,7 +221,7 @@ enum class Feature
 {
     Blend,
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     ClipDist,
 #endif
     Culling,
@@ -228,7 +229,7 @@ enum class Feature
     DebugOutput,
     DebugOutputSync,
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     DepthClamp,
 #endif
     DepthTest,
@@ -236,12 +237,12 @@ enum class Feature
 
     FramebufferSRGB,
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     LineSmooth,
     PolygonSmooth,
 #endif
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     PrimitiveRestart,
 #endif
     PrimitiveRestartFixedIdx,
@@ -249,7 +250,7 @@ enum class Feature
     SampleAlphaToCoverage,
     SampleCoverage,
     SampleMask,
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     SampleAlphaToOne,
     SampleShading,
 #endif
@@ -259,18 +260,18 @@ enum class Feature
     ScissorTest,
     StencilTest,
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     PointSize,
 #endif
 
     SeamlessCubemap,
 
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     Multisample,
 #endif
 
     PolygonOffsetFill,
-#if defined(COFFEE_GLEAM_DESKTOP)
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     PolygonOffsetPoint,
     PolygonOffsetLine,
 #endif
@@ -281,13 +282,13 @@ enum class BufType
 
     ArrayData = GL_ARRAY_BUFFER,
     ElementData = GL_ELEMENT_ARRAY_BUFFER,
-#if defined(COFFEE_ONLY_GLES20)
-    UniformData = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     UniformData = GL_UNIFORM_BUFFER,
+#else
+    UniformData = GL_NONE,
 #endif
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     ShaderData = GL_SHADER_STORAGE_BUFFER,
     AtomicData = GL_ATOMIC_COUNTER_BUFFER,
     QueryData = GL_QUERY_BUFFER,
@@ -296,12 +297,12 @@ enum class BufType
     AtomicData = 0,
     QueryData = 0,
 #endif
-#if defined(COFFEE_ONLY_GLES20)
-    XFBData = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     XFBData = GL_TRANSFORM_FEEDBACK_BUFFER,
+#else
+    XFBData = GL_NONE,
 #endif
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     DrawcallData = GL_DRAW_INDIRECT_BUFFER,
     ComputecallData = GL_DISPATCH_INDIRECT_BUFFER,
 #else
@@ -309,31 +310,31 @@ enum class BufType
     ComputecallData = 0,
 #endif
 
-#if defined(COFFEE_ONLY_GLES20)
-    PixelUData = GL_NONE,
-    PixelPData = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     PixelUData = GL_PIXEL_UNPACK_BUFFER,
     PixelPData = GL_PIXEL_PACK_BUFFER,
+#else
+    PixelUData = GL_NONE,
+    PixelPData = GL_NONE,
 #endif
 };
 
 enum class Texture
 {
     T2D = GL_TEXTURE_2D,
-#if defined(COFFEE_ONLY_GLES20)
-    T3D = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     T3D = GL_TEXTURE_3D,
+#else
+    T3D = GL_NONE,
 #endif
     Cubemap = GL_TEXTURE_CUBE_MAP,
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     Rect = GL_TEXTURE_RECTANGLE,
 #endif
-#if defined(COFFEE_ONLY_GLES20)
-    T2DArray = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     T2DArray = GL_TEXTURE_2D_ARRAY,
+#else
+    T2DArray = GL_NONE,
 #endif
 #if GL_VERSION_VERIFY(0x330, 0x320)
     CubemapArray = GL_TEXTURE_CUBE_MAP_ARRAY,
@@ -346,7 +347,7 @@ enum class Texture
     CubeZ_P = GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
     CubeZ_N = GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     Proxy2D = GL_PROXY_TEXTURE_2D,
     Proxy3D = GL_PROXY_TEXTURE_3D,
     ProxyCubemap = GL_PROXY_TEXTURE_CUBE_MAP,
@@ -365,7 +366,7 @@ enum class Texture
 
 enum class DrawMode
 {
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     Point = GL_POINT,
     Line = GL_LINE,
     Fill = GL_FILL,
@@ -378,17 +379,17 @@ enum class DrawMode
 
 enum class QueryT
 {
-#if defined(COFFEE_ONLY_GLES20)
-    AnySamples = GL_NONE,
-    AnySamplesCon = GL_NONE,
-    XFGen = GL_NONE,
-#else
+#if GL_VERSION_VERIFY(0x300, 0x300)
     AnySamples = GL_ANY_SAMPLES_PASSED,
     AnySamplesCon = GL_ANY_SAMPLES_PASSED_CONSERVATIVE,
     XFGen = GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN,
+#else
+    AnySamples = GL_NONE,
+    AnySamplesCon = GL_NONE,
+    XFGen = GL_NONE,
 #endif
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     TimeElapsed = GL_TIME_ELAPSED,
 
     Samples = GL_SAMPLES_PASSED,
@@ -408,15 +409,15 @@ enum class PatchProperty
 #else
     Vertices = GL_NONE,
 #endif
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     DefOuterLevel = GL_PATCH_DEFAULT_OUTER_LEVEL,
     DefInnerLevel = GL_PATCH_DEFAULT_INNER_LEVEL,
 #endif
 };
 
-C_FLAGS(BufBit,uint32);
-C_FLAGS(ShaderStage,uint32);
-C_FLAGS(Face,uint32);
+C_FLAGS(BufBit,u32);
+C_FLAGS(ShaderStage,u32);
+C_FLAGS(Face,u32);
 
 }
 }

--- a/include/coffee/graphics/apis/gleam/levels/shared/queries/old_queries.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/queries/old_queries.h
@@ -21,12 +21,16 @@ struct CGL_Old_Queries
     {glGetQueryiv(to_enum(t),p,v);}
 
     /* GetQueryObject*v */
+#if GL_VERSION_VERIFY(0x200, 0x300)
     STATICINLINE void QueryGetObjectuiv(CGhnd h,CGenum f,uint32* d)
     {glGetQueryObjectuiv(h,f,d);}
+#endif
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x200, GL_VERSION_NONE)
     STATICINLINE void QueryGetObjectiv(CGhnd h,CGenum f,int32* d)
     {glGetQueryObjectiv(h,f,d);}
+#endif
+#if GL_VERSION_VERIFY(0x320, GL_VERSION_NONE)
     STATICINLINE void QueryGetObjecti64v(CGhnd h,CGenum f,int64* d)
     {glGetQueryObjecti64v(h,f,d);}
     STATICINLINE void QueryGetObjectui64v(CGhnd h,CGenum f,uint64* d)

--- a/include/coffee/graphics/apis/gleam/levels/shared/shaders/arb_program_interface_query.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/shaders/arb_program_interface_query.h
@@ -33,7 +33,7 @@ struct CGL_ProgramInterfaceQuery
     }
     STATICINLINE int32 ProgramGetResourceLoc(CGhnd h,CGenum e,cstring n)
     {return glGetProgramResourceLocation(h,e,n);}
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x410, GL_VERSION_NONE)
     STATICINLINE int32 ProgramGetResourceLocIdx(CGhnd h,CGenum e,cstring n)
     {return glGetProgramResourceLocationIndex(h,e,n);}
 #endif

--- a/include/coffee/graphics/apis/gleam/levels/shared/shaders/compiling.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/shaders/compiling.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../gl_shared_include.h"
+#include "../gl_shared_types.h"
 #include <coffee/core/types/tdef/integertypes.h>
 
 namespace Coffee {
@@ -190,7 +190,7 @@ struct CGL_Old_ShaderCompiler {
         int32 size;
     };
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE
     void ProgramUnifBlockGet(CGhnd h, uint32* n, UnifBlkInfo** blocks)
     {
@@ -223,9 +223,7 @@ struct CGL_Old_ShaderCompiler {
                                       (*blocks)[i].index);
         }
     }
-#endif
 
-#if !defined(COFFEE_ONLY_GLES20)
     STATICINLINE uint32 ProgramUnifBlockGetLoc(CGhnd h, cstring n)
     {
         return glGetUniformBlockIndex(h, n);

--- a/include/coffee/graphics/apis/gleam/levels/shared/shaders/uniforms.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/shaders/uniforms.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../gl_shared_include.h"
+#include "../gl_shared_types.h"
 #include <coffee/core/types/tdef/integertypes.h>
 #include <coffee/core/types/vector_types.h>
 
@@ -69,7 +69,7 @@ struct CGL_Old_Uniforms
         glUniformMatrix4fv(l, c, (t) ? GL_TRUE : GL_FALSE, (scalar*)d);
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void Uniformfv(
         int32 l, int32 c, bool t, const _cbasic_tmnmatrix<scalar, 2, 3>* d)
     {

--- a/include/coffee/graphics/apis/gleam/levels/shared/textures/old_textures.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/textures/old_textures.h
@@ -47,7 +47,7 @@ struct CGL_Old_Textures
             to_enum(dt),
             p);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void TexImage3D(
         Texture         t,
         uint32          level,
@@ -84,7 +84,7 @@ struct CGL_Old_Textures
         szptr*  size,
         uint32  mip = 0)
     {
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
         int32 w_t, h_t, d_t;
         TexGetLevelParameteriv(t, mip, GL_TEXTURE_WIDTH, &w_t);
         TexGetLevelParameteriv(t, mip, GL_TEXTURE_HEIGHT, &h_t);
@@ -140,7 +140,7 @@ struct CGL_Old_Textures
         *size = 0;
 #endif
     }
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     STATICINLINE void TexGetCompressedSize(
         Texture t, uint32& w, uint32& h, uint32& d, szptr& size)
     {
@@ -153,7 +153,7 @@ struct CGL_Old_Textures
     }
 #endif
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     STATICINLINE void TexGetImage(
         Texture         t,
         uint32          level,
@@ -199,7 +199,7 @@ struct CGL_Old_Textures
             to_enum(dt),
             p);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void TexSubImage3D(
         Texture   t,
         uint32    level,
@@ -250,7 +250,7 @@ struct CGL_Old_Textures
             sz,
             p);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void TexImageCompressed3D(
         Texture t,
         int32   level,
@@ -299,7 +299,7 @@ struct CGL_Old_Textures
             sz,
             p);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void TexSubImageCompressed3D(
         Texture t,
         uint32  level,
@@ -357,7 +357,7 @@ struct CGL_Old_Textures
     {
         glCopyTexSubImage2D(to_enum(t), level, xo, yo, x, y, w, h);
     }
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void TexCopySubImage3D(
         Texture t,
         uint32  level,
@@ -442,7 +442,7 @@ struct CGL_Old_Textures
         glTexParameterIuiv(to_enum(t), e, v);
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x330, 0x300)
     /* Samplers */
     STATICINLINE void SamplerBind(uint32 i, CGhnd h)
     {

--- a/include/coffee/graphics/apis/gleam/levels/shared/vertex/arb_vertex_attrib_binding.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/vertex/arb_vertex_attrib_binding.h
@@ -39,7 +39,7 @@ struct CGL_VertexAttribBinding
         glBindVertexBuffer(idx, h, off, stride);
     }
 
-#ifdef COFFEE_GLEAM_DESKTOP
+#if GL_VERSION_VERIFY(0x300, GL_VERSION_NONE)
     STATICINLINE void VAOAttribFormatL(uint32 i, i32 s, TypeEnum t,
                                        uint32 off)
     {

--- a/include/coffee/graphics/apis/gleam/levels/shared/vertex/old_vaos.h
+++ b/include/coffee/graphics/apis/gleam/levels/shared/vertex/old_vaos.h
@@ -29,7 +29,7 @@ struct CGL_Old_VAOs
                               C_RCAST<void*>(offset));
     }
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     STATICINLINE void VAOBind(CGhnd h)
     {
         glBindVertexArray(h);

--- a/include/coffee/graphics/apis/gleam/rhi/gleam_api_rhi.h
+++ b/include/coffee/graphics/apis/gleam/rhi/gleam_api_rhi.h
@@ -115,7 +115,7 @@ struct GLEAM_API : GraphicsAPI
     {
         Vector<CommandBuffer> cmdBufs;
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
         struct IndirectCall
         {
             union{
@@ -154,7 +154,7 @@ struct GLEAM_API : GraphicsAPI
 
     using OPT_DRAW = OptimizedDraw;
 
-#if !defined(COFFEE_ONLY_GLES20)
+#if GL_VERSION_VERIFY(0x300, 0x300)
     using OptMap = Map<CommandBuffer*, OPT_DRAW::MultiDrawData>;
 #endif
 

--- a/include/coffee/graphics/apis/gleam/rhi/gleam_data.h
+++ b/include/coffee/graphics/apis/gleam/rhi/gleam_data.h
@@ -53,7 +53,7 @@ struct GLEAM_DataStore
         bool draw_indirect = false;
 
 #if defined(COFFEE_GLEAM_DESKTOP)
-        bool base_instance;
+        bool base_instance = false;
         bool direct_state = false;
 #else
         bool qcom_tiling = false;


### PR DESCRIPTION
Also fixes for using Emscripten with WebGL 2, closer to working